### PR TITLE
fix utf8 string wrapped default arguments

### DIFF
--- a/dataflake/fakeldap/tests/test_utils.py
+++ b/dataflake/fakeldap/tests/test_utils.py
@@ -30,7 +30,10 @@ class HashPwdTests(unittest.TestCase):
         self.assertTrue(isinstance(pwd, six.binary_type))
         self.assertTrue(pwd.startswith(b'{SHA}'))
 
-    def test_hash_to_utf8(self):
+
+class ConstraintUtilTests(unittest.TestCase):
+
+    def test_to_utf8(self):
         from dataflake.fakeldap.utils import utf8_string
         @utf8_string('test')
         def _fn_with_opt_args(test='string'):

--- a/dataflake/fakeldap/tests/test_utils.py
+++ b/dataflake/fakeldap/tests/test_utils.py
@@ -29,3 +29,10 @@ class HashPwdTests(unittest.TestCase):
         pwd = hash_pwd(u'bjørn')
         self.assertTrue(isinstance(pwd, six.binary_type))
         self.assertTrue(pwd.startswith(b'{SHA}'))
+
+    def test_hash_to_utf8(self):
+        from dataflake.fakeldap.utils import utf8_string
+        @utf8_string('test')
+        def _fn_with_opt_args(test='string'):
+            return True
+        self.assertTrue(_fn_with_opt_args())

--- a/dataflake/fakeldap/utils.py
+++ b/dataflake/fakeldap/utils.py
@@ -66,8 +66,10 @@ def utf8_string(*tested):
             for arg_name, arg_index in test_indices:
                 if arg_name in kw:
                     arg_val = kw.get(arg_name)
-                else:
+                elif arg_index < len(args):
                     arg_val = args[arg_index]
+                else:
+                    continue # fallback to default arguments
 
                 if not isinstance(arg_val, six.binary_type):
                     msg = 'Parameter %s must be UTF-8, found %s (%s)'


### PR DESCRIPTION
The `utf8_string` decorator inspects the wrapped function signature and expects all arguments to be passed from the caller. Instead, skip arguments out of range, presuming default values to be valid and allowing missing required arguments to fail upward with `TypeError`s. 

This fix eases use of `fakeldap.search_s`, which provides a default argument for `query`.